### PR TITLE
Fix '-z -i' combination

### DIFF
--- a/dmenu.c
+++ b/dmenu.c
@@ -616,6 +616,8 @@ strchri(const char *s, int c) {
 		l = strchr(s, c);
 		u = strchr(s, toupper(c));
 	}
+
+  return u == NULL? l : u;
 }
 
 void


### PR DESCRIPTION
This patch allows case-insensitive fuzzy matching.
